### PR TITLE
Use QueryKeyGenerator.generate to clear a cache

### DIFF
--- a/src/main/java/aoshima/web/RootController.java
+++ b/src/main/java/aoshima/web/RootController.java
@@ -1,5 +1,6 @@
 package aoshima.web;
 
+import aoshima.key.QueryKeyGenerator;
 import aoshima.model.PrestoQueryResult;
 import com.facebook.presto.client.*;
 import io.airlift.http.client.HttpClientConfig;
@@ -74,7 +75,8 @@ public class RootController {
 
     @RequestMapping(value = "/clear_cache", method = RequestMethod.DELETE)
     public ResponseEntity<?> clearCache(@RequestBody String key) {
-        caffeineCacheManager.getCache("query_result").evict(key);
+        String formattedKey = String.valueOf(new QueryKeyGenerator().generate(null, null, key));
+        caffeineCacheManager.getCache("query_result").evict(formattedKey);
         return ResponseEntity.ok(Arrays.asList(key));
     }
 


### PR DESCRIPTION
We wanna clear the cache with `/clear_cache` without Aoshima web UI.
But the cache keys are formatted queries, we want to delete it without formatted.

Add `QueryKeyGenerator.generate` for formatting queries in `/clear_cache`.